### PR TITLE
Parse OGP also When other attributes are included in the meta tag.

### DIFF
--- a/OpenGraph.xcodeproj/project.pbxproj
+++ b/OpenGraph.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6A7310FF1E279D5D00CE1756 /* example3.com.html in Resources */ = {isa = PBXBuildFile; fileRef = 6A7310FB1E279C7E00CE1756 /* example3.com.html */; };
+		6A7311001E279D5D00CE1756 /* example2.com.html in Resources */ = {isa = PBXBuildFile; fileRef = 6A7310FC1E279C7E00CE1756 /* example2.com.html */; };
 		7B24FB191D3B2583005275B0 /* OpenGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B24FB181D3B2583005275B0 /* OpenGraph.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7B24FB201D3B2583005275B0 /* OpenGraph.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7B24FB151D3B2583005275B0 /* OpenGraph.framework */; };
 		7B24FB3E1D3B26C4005275B0 /* OpenGraphTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B24FB3D1D3B26C4005275B0 /* OpenGraphTests.swift */; };
@@ -29,6 +31,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		6A7310FB1E279C7E00CE1756 /* example3.com.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = example3.com.html; sourceTree = "<group>"; };
+		6A7310FC1E279C7E00CE1756 /* example2.com.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = example2.com.html; sourceTree = "<group>"; };
 		7B24FB151D3B2583005275B0 /* OpenGraph.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OpenGraph.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B24FB181D3B2583005275B0 /* OpenGraph.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OpenGraph.h; sourceTree = "<group>"; };
 		7B24FB1A1D3B2583005275B0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -98,6 +102,8 @@
 			isa = PBXGroup;
 			children = (
 				7B24FB521D3B2DD4005275B0 /* example.com.html */,
+				6A7310FC1E279C7E00CE1756 /* example2.com.html */,
+				6A7310FB1E279C7E00CE1756 /* example3.com.html */,
 				7B24FB261D3B2583005275B0 /* Info.plist */,
 				7B24FB3D1D3B26C4005275B0 /* OpenGraphTests.swift */,
 			);
@@ -199,6 +205,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6A7310FD1E279C7E00CE1756 /* example3.com.html in Resources */,
+				6A7310FE1E279C7E00CE1756 /* example2.com.html in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -206,6 +214,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6A7310FF1E279D5D00CE1756 /* example3.com.html in Resources */,
+				6A7311001E279D5D00CE1756 /* example2.com.html in Resources */,
 				7B24FB531D3B2DD4005275B0 /* example.com.html in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Tests/OpenGraphTests.swift
+++ b/Tests/OpenGraphTests.swift
@@ -74,6 +74,66 @@ class OpenGraphTests: XCTestCase {
         }
     }
     
+    // Detect og:xxx also when order of attributes are reversed.
+    func testFetching2() {
+        let responseArrived = expectation(description: "response of async request has arrived")
+        
+        OHHTTPStubs.stubRequests(passingTest: { request -> Bool in
+            return true
+        }) { request -> OHHTTPStubsResponse in
+            let path = Bundle(for: type(of: self)).path(forResource: "example2.com", ofType: "html")
+            return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: nil)
+        }
+        
+        let url = URL(string: "https://www.example2.com")!
+        var og: OpenGraph!
+        var error: Error?
+        OpenGraph.fetch(url: url) { _og, _error in
+            og = _og
+            error = _error
+            responseArrived.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10) { _ in
+            XCTAssert(og[.title] == "example2.com title")
+            XCTAssert(og[.type] == "website2")
+            XCTAssert(og[.url] == "https://www.example2.com")
+            XCTAssert(og[.image] == "https://www.example2.com/images/example2.png")
+            
+            XCTAssert(error == nil)
+        }
+    }
+    
+    // When the meta tag contains other attributes.
+    func testFetching3() {
+        let responseArrived = expectation(description: "response of async request has arrived")
+        
+        OHHTTPStubs.stubRequests(passingTest: { request -> Bool in
+            return true
+        }) { request -> OHHTTPStubsResponse in
+            let path = Bundle(for: type(of: self)).path(forResource: "example3.com", ofType: "html")
+            return OHHTTPStubsResponse(fileAtPath: path!, statusCode: 200, headers: nil)
+        }
+        
+        let url = URL(string: "https://www.example3.com")!
+        var og: OpenGraph!
+        var error: Error?
+        OpenGraph.fetch(url: url) { _og, _error in
+            og = _og
+            error = _error
+            responseArrived.fulfill()
+        }
+        
+        waitForExpectations(timeout: 10) { _ in
+            XCTAssert(og[.title] == "example3.com title")
+            XCTAssert(og[.type] == "website3")
+            XCTAssert(og[.url] == "https://www.example3.com")
+            XCTAssert(og[.image] == "https://www.example3.com/images/example3.png")
+            
+            XCTAssert(error == nil)
+        }
+    }
+
     func testHTTPResponseError() {
         let responseArrived = expectation(description: "response of async request has arrived")
         

--- a/Tests/example2.com.html
+++ b/Tests/example2.com.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <meta content="example2.com title" property="og:title" />
+    <meta content="website2" property="og:type" />
+    <meta content="https://www.example2.com" property="og:url" />
+    <meta content="https://www.example2.com/images/example2.png" property="og:image" />
+    <meta content="example2.com description" property="og:description" />
+  </head>
+  <body>
+    <p>Hello, world.</p>
+  </body>
+</html>

--- a/Tests/example3.com.html
+++ b/Tests/example3.com.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <meta property="og:title" content="example3.com title" id="og-title"/>
+    <meta content="website3" id="og-type" property="og:type" />
+    <meta id="og-url" property="og:url" content="https://www.example3.com" />
+    <meta property="og:image" id="og-image" content="https://www.example3.com/images/example3.png" />
+    <meta content="example3.com description" id="og-description" property="og:description"/>
+  </head>
+  <body>
+    <p>Hello, world.</p>
+  </body>
+</html>


### PR DESCRIPTION
Update parse method to match not only
```html
<meta property="og:title" content="foobar" />
```
, but also
```html
<meta property="og:title" content="foobar" id="foobar" />
```
Because I found [this page](http://www.afpbb.com/articles/-/3113660).
