### PR TITLE
Add CaseIterable to OpenGraphMetadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode9
+osx_image: xcode10
 
 xcode_project: OpenGraph.xcodeproj
 xcode_scheme: OpenGraph

--- a/OpenGraph/OpenGraphMetadata.swift
+++ b/OpenGraph/OpenGraphMetadata.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum OpenGraphMetadata: String {
+public enum OpenGraphMetadata: String, CaseIterable {
     // Basic Metadata
     case title
     case type
@@ -63,3 +63,28 @@ public enum OpenGraphMetadata: String {
     case profileUsername  = "profile:username"
     case profileGender    = "profile:gender"
 }
+
+#if !swift(>=4.2)
+public protocol CaseIterable {
+    associatedtype AllCases: Collection where AllCases.Element == Self
+    static var allCases: AllCases { get }
+}
+extension CaseIterable where Self: Hashable {
+    static var allCases: [Self] {
+        return [Self](AnySequence { () -> AnyIterator<Self> in
+            var raw = 0
+            var first: Self?
+            return AnyIterator {
+                let current = withUnsafeBytes(of: &raw) { $0.load(as: Self.self) }
+                if raw == 0 {
+                    first = current
+                } else if current == first {
+                    return nil
+                }
+                raw += 1
+                return current
+            }
+        })
+    }
+}
+#endif


### PR DESCRIPTION
This adds the new in Swift 4.2 `CaseIterable` to the `OpenGraphMetadata` enum to allow iterating all possible cases of the enum. For those not on Swift 4.2 yet, there is a compatibility protocol [I found on StackOverflow](https://stackoverflow.com/a/49588446/486182).

This allows me to iterate the entire OpenGraph dictionary by its keys without needing to make the dictionary public.