### PR TITLE
Modify completion as `Result` type

### DIFF
--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,1 +1,1 @@
-github "AliSoftware/OHHTTPStubs" "6.0.0"
+github "AliSoftware/OHHTTPStubs" "8.0.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "AliSoftware/OHHTTPStubs" "6.0.0"
+github "AliSoftware/OHHTTPStubs" "8.0.0"

--- a/OpenGraph.xcodeproj/project.pbxproj
+++ b/OpenGraph.xcodeproj/project.pbxproj
@@ -405,7 +405,7 @@
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -435,7 +435,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				WATCHOS_DEPLOYMENT_TARGET = 2.0;
 			};
@@ -456,7 +456,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "net.cloud-dj.OpenGraphTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -474,7 +474,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "net.cloud-dj.OpenGraphTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/README.md
+++ b/README.md
@@ -3,35 +3,39 @@
 OpenGraph is a Swift wrapper for the OGP ([Open Graph protocol](http://ogp.me/)).
 You can fetch OpenGraph,then you can access the attributes with subscript and the key provided by enum type.
 ```swift
-OpenGraph.fetch(url) { og, error in
-    print(og?[.title]) // => og:title of the web site
-    print(og?[.type])  // => og:type of the web site
-    print(og?[.image]) // => og:image of the web site
-    print(og?[.url])   // => og:url of the web site
+OpenGraph.fetch(url: url) { result in
+    switch result {
+    case .success(let og):
+        print(og[.title]) // => og:title of the web site
+        print(og[.type])  // => og:type of the web site
+        print(og[.image]) // => og:image of the web site
+        print(og[.url])   // => og:url of the web site
+    case .failure(let error):
+        print(error)
+    }
 }
 ```
 
 If you want to use Rx interface, use an extension below.
 ```swift
-extension OpenGraph {
-    static func rx_fetch(url: URL?) -> Observable<OpenGraph?> {
+extension Reactive where Base: OpenGraph {
+    static func fetch(url: URL?) -> Observable<OpenGraph> {
         return Observable.create { observer in
             guard let url = url else {
                 observer.onCompleted()
                 return Disposables.create()
             }
-            
-            OpenGraph.fetch(url: url) { og, err in
-                if let og = og {
+
+            OpenGraph.fetch(url: url) { result in
+                switch result {
+                case .success(let og):
                     observer.onNext(og)
+                case .failure(let error):
+                    observer.onError(error)
                 }
-                if let err = err {
-                    observer.onError(err)
-                }
-                
                 observer.onCompleted()
             }
-            
+
             return Disposables.create()
         }
     }

--- a/Tests/OpenGraphTests.swift
+++ b/Tests/OpenGraphTests.swift
@@ -33,9 +33,11 @@ class OpenGraphTests: XCTestCase {
         var og: OpenGraph!
         var error: Error?
         let headers = ["User-Agent": "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36"]
-        OpenGraph.fetch(url: url, headers: headers) { (_og, _error) in
-            og = _og
-            error = _error
+        OpenGraph.fetch(url: url, headers: headers) { result in
+            switch result {
+            case .success(let _og): og = _og
+            case .failure(let _error): error = _error
+            }
             responseArrived.fulfill()
         }
         
@@ -57,9 +59,11 @@ class OpenGraphTests: XCTestCase {
         let url = URL(string: "https://www.example.com")!
         var og: OpenGraph!
         var error: Error?
-        OpenGraph.fetch(url: url) { _og, _error in
-            og = _og
-            error = _error
+        OpenGraph.fetch(url: url) { result in
+            switch result {
+            case .success(let _og): og = _og
+            case .failure(let _error): error = _error
+            }
             responseArrived.fulfill()
         }
         
@@ -82,9 +86,11 @@ class OpenGraphTests: XCTestCase {
         let url = URL(string: "https://www.example.com")!
         var og: OpenGraph!
         var error: Error?
-        OpenGraph.fetch(url: url) { _og, _error in
-            og = _og
-            error = _error
+        OpenGraph.fetch(url: url) { result in
+            switch result {
+            case .success(let _og): og = _og
+            case .failure(let _error): error = _error
+            }
             responseArrived.fulfill()
         }
         
@@ -110,9 +116,11 @@ class OpenGraphTests: XCTestCase {
         let url = URL(string: "https://www.example.com")!
         var og: OpenGraph?
         var error: Error?
-        OpenGraph.fetch(url: url) { _og, _error in
-            og = _og
-            error = _error
+        OpenGraph.fetch(url: url) { result in
+            switch result {
+            case .success(let _og): og = _og
+            case .failure(let _error): error = _error
+            }
             responseArrived.fulfill()
         }
         
@@ -144,9 +152,11 @@ class OpenGraphTests: XCTestCase {
         let url = URL(string: "https://www.example.com")!
         var og: OpenGraph?
         var error: Error?
-        OpenGraph.fetch(url: url) { _og, _error in
-            og = _og
-            error = _error
+        OpenGraph.fetch(url: url) { result in
+            switch result {
+            case .success(let _og): og = _og
+            case .failure(let _error): error = _error
+            }
             responseArrived.fulfill()
         }
         


### PR DESCRIPTION
Now we don't have to unwrapping `OpenGraph`.
```swift
OpenGraph.fetch(url: url) { result in
    switch result {
    case .success(let og):
        print(og[.title]) // => og:title of the web site
        print(og[.type])  // => og:type of the web site
        print(og[.image]) // => og:image of the web site
        print(og[.url])   // => og:url of the web site
    case .failure(let error):
        print(error)
    }
}
```