### PR TITLE
Accept some edge case

### DIFF
--- a/OpenGraph.podspec
+++ b/OpenGraph.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name        = "OpenGraph"
-  s.version     = "1.2.0"
+  s.version     = "1.2.1"
   s.summary     = "A Swift wrapper for the Open Graph protocol."
   s.homepage    = "https://github.com/satoshi-takano/OpenGraph"
   s.license     = {
     :type => "MIT",
     :text => <<-LICENSE
 The MIT License (MIT)
-Copyright (c) 2018 Satoshi Takano
+Copyright (c) Satoshi Takano
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/OpenGraph/OpenGraphParser.swift
+++ b/OpenGraph/OpenGraphParser.swift
@@ -20,11 +20,11 @@ extension OpenGraphParser {
 
         // prepare regular expressions to extract og property and content.
         let propertyRegexp = try! NSRegularExpression(
-            pattern: "\\sproperty=(?:\"|\')og:([a-zA_Z:]+?)(?:\"|\')",
+            pattern: "\\sproperty=(?:\"|\')*og:([a-zA_Z:]+)(?:\"|\')*",
             options: []
         )
         let contentRegexp = try! NSRegularExpression(
-            pattern: "\\scontent=\"(.*?)\"",
+            pattern: "\\scontent=\\\\*?\"(.*?)\\\\*?\"",
             options: []
         )
         
@@ -43,7 +43,7 @@ extension OpenGraphParser {
                 var contentMatches = contentRegexp.matches(in: metaTag, options: [], range: NSMakeRange(0, metaTag.count))
                 if contentMatches.first == nil {
                     let contentRegexp = try! NSRegularExpression(
-                        pattern: "\\scontent='(.*?)'",
+                        pattern: "\\scontent=\\\\*?'(.*?)\\\\*?'",
                         options: []
                     )
                     contentMatches = contentRegexp.matches(in: metaTag, options: [], range: NSMakeRange(0, metaTag.count))

--- a/Tests/ogp.html
+++ b/Tests/ogp.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <meta charset='utf-8'>
-    <meta property="og:title" content=" < It's example.com title > "><meta property="og:type" content="website" />
-    <meta property="og:url" content="https://www.example.com" />
+    <meta property=og:title content=" < It's example.com title > "><meta property="og:type" content="website" />
+    <meta property="og:url" content=\"https://www.example.com\" />
     
     <!-- og property that has an other attributes. -->
     <meta id="og-image" property="og:image" content="https://www.example.com/images/example.png" />


### PR DESCRIPTION
#39 
I found USA Today uses meta tags like this.
```xml
<meta property=og:title content=\"Betsy DeVos orders probe after USA TODAY finds college evidently without faculty, students\"/>
```
I made changes to accept a meta tag which doesn't surround their key with quote or surround their value with extra backquotes.