### PR TITLE
Add URLSessionConfiguration parameter for OpenGraph.fetch

### DIFF
--- a/OpenGraph/OpenGraph.swift
+++ b/OpenGraph/OpenGraph.swift
@@ -5,12 +5,11 @@ public struct OpenGraph {
     public let source: [OpenGraphMetadata: String]
     
     @discardableResult
-    public static func fetch(url: URL, headers: [String: String]? = nil, completion: @escaping (Result<OpenGraph, Error>) -> Void) -> URLSessionDataTask {
+    public static func fetch(url: URL, headers: [String: String]? = nil, configuration: URLSessionConfiguration = .default, completion: @escaping (Result<OpenGraph, Error>) -> Void) -> URLSessionDataTask {
         var mutableURLRequest = URLRequest(url: url)
         headers?.compactMapValues { $0 }.forEach {
             mutableURLRequest.setValue($1, forHTTPHeaderField: $0)
         }
-        let configuration = URLSessionConfiguration.default
         let session = URLSession(configuration: configuration)
         let task = session.dataTask(with: mutableURLRequest, completionHandler: { data, response, error in
             if let error = error {


### PR DESCRIPTION
This is used to adjust details, such as timeout.