### PR TITLE
Fix async/await for macOS 10.15, iOS 13, watchOS 6, tvOS 13

### DIFF
--- a/OpenGraph.xcodeproj/project.pbxproj
+++ b/OpenGraph.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A78BBD027972EB30049F53B /* URLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A78BBCF27972EB30049F53B /* URLSession.swift */; };
 		4204E998275B260700AB31CC /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4204E997275B260700AB31CC /* Data.swift */; };
 		4204EA19275B76AE00AB31CC /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4204EA18275B76AE00AB31CC /* String.swift */; };
 		6A7310FF1E279D5D00CE1756 /* example3.com.html in Resources */ = {isa = PBXBuildFile; fileRef = 6A7310FB1E279C7E00CE1756 /* example3.com.html */; };
@@ -33,6 +34,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0A78BBCF27972EB30049F53B /* URLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSession.swift; sourceTree = "<group>"; };
 		4204E997275B260700AB31CC /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		4204EA18275B76AE00AB31CC /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		6A7310FB1E279C7E00CE1756 /* example3.com.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = example3.com.html; sourceTree = "<group>"; };
@@ -75,6 +77,7 @@
 			children = (
 				4204E997275B260700AB31CC /* Data.swift */,
 				4204EA18275B76AE00AB31CC /* String.swift */,
+				0A78BBCF27972EB30049F53B /* URLSession.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -267,6 +270,7 @@
 			files = (
 				7B24FB461D3B27E5005275B0 /* OpenGraph.swift in Sources */,
 				4204E998275B260700AB31CC /* Data.swift in Sources */,
+				0A78BBD027972EB30049F53B /* URLSession.swift in Sources */,
 				7B24FB4A1D3B27E5005275B0 /* OpenGraphResponseError.swift in Sources */,
 				7B24FB491D3B27E5005275B0 /* OpenGraphParser.swift in Sources */,
 				4204EA19275B76AE00AB31CC /* String.swift in Sources */,

--- a/Sources/OpenGraph/Extension/URLSession.swift
+++ b/Sources/OpenGraph/Extension/URLSession.swift
@@ -10,10 +10,7 @@ import Foundation
 
 // Taken from John Sundell's [AsyncCompatibilityKit](https://github.com/JohnSundell/AsyncCompatibilityKit/blob/main/Sources/URLSession%2BAsync.swift)
 
-@available(iOS, introduced: 13, obsoleted: 15)
-@available(macOS, introduced: 10.15, obsoleted: 12)
-@available(watchOS, introduced: 6, obsoleted: 8)
-@available(tvOS, introduced: 13, obsoleted: 15)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public extension URLSession {
     /// Start a data task with a URL using async/await.
     /// - parameter url: The URL to send a request to.

--- a/Sources/OpenGraph/Extension/URLSession.swift
+++ b/Sources/OpenGraph/Extension/URLSession.swift
@@ -1,0 +1,56 @@
+//
+//  URLSession.swift
+//  OpenGraph
+//
+//  Created by Rudrank Riyam on 18/01/22.
+//  Copyright © 2022 Satoshi Takano. All rights reserved.
+//
+
+import Foundation
+
+// Taken from John Sundell's [AsyncCompatibilityKit](https://github.com/JohnSundell/AsyncCompatibilityKit/blob/main/Sources/URLSession%2BAsync.swift)
+
+@available(iOS, introduced: 13, obsoleted: 15)
+@available(macOS, introduced: 10.15, obsoleted: 12)
+@available(watchOS, introduced: 6, obsoleted: 8)
+@available(tvOS, introduced: 13, obsoleted: 15)
+public extension URLSession {
+    /// Start a data task with a URL using async/await.
+    /// - parameter url: The URL to send a request to.
+    /// - returns: A tuple containing the binary `Data` that was downloaded,
+    ///   as well as a `URLResponse` representing the server's response.
+    /// - throws: Any error encountered while performing the data task.
+    func data(from url: URL) async throws -> (Data, URLResponse) {
+        try await data(for: URLRequest(url: url))
+    }
+    
+    /// Start a data task with a `URLRequest` using async/await.
+    /// - parameter request: The `URLRequest` that the data task should perform.
+    /// - returns: A tuple containing the binary `Data` that was downloaded,
+    ///   as well as a `URLResponse` representing the server's response.
+    /// - throws: Any error encountered while performing the data task.
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        var dataTask: URLSessionDataTask?
+        let onCancel = { dataTask?.cancel() }
+        
+        return try await withTaskCancellationHandler(
+            handler: {
+                onCancel()
+            },
+            operation: {
+                try await withCheckedThrowingContinuation { continuation in
+                    dataTask = self.dataTask(with: request) { data, response, error in
+                        guard let data = data, let response = response else {
+                            let error = error ?? URLError(.badServerResponse)
+                            return continuation.resume(throwing: error)
+                        }
+                        
+                        continuation.resume(returning: (data, response))
+                    }
+                    
+                    dataTask?.resume()
+                }
+            }
+        )
+    }
+}


### PR DESCRIPTION
While Apple has back-ported concurrency to macOS 10.15, iOS 13, watchOS 6, tvOS 13, unfortunately, it hasn't backported the async/await methods written for iOS 15+ and others. 

So, in the current state, running the project gives errors that the `data` method is available only for iOS 15+. 

To fix this, we've to write our own variation of `data` while Apple backports this method to iOS 13+. 

I've taken the solution from John's [AsyncCompatibilityKit](https://github.com/JohnSundell/AsyncCompatibilityKit/blob/main/Sources/URLSession%2BAsync.swift) that serves this purpose.