### PR TITLE
Support multiple encoding regardless of platforms

### DIFF
--- a/Sources/OpenGraph/Extension/String.swift
+++ b/Sources/OpenGraph/Extension/String.swift
@@ -9,11 +9,21 @@
 import Foundation
 
 extension String {
-    init?(data: Data, `default`: String.Encoding = .utf8) {
-        var encoding = `default`
-        if #available(macOS 10.10, *) {
-            encoding = data.stringEncoding ?? `default`
-        }
+    init?(data: Data, textEncodingName: String? = nil, `default`: String.Encoding = .utf8) {
+        let encoding: String.Encoding = {
+            if let textEncodingName = textEncodingName {
+                let cfe = CFStringConvertIANACharSetNameToEncoding(textEncodingName as CFString)
+                if cfe != kCFStringEncodingInvalidId {
+                    let se = CFStringConvertEncodingToNSStringEncoding(cfe)
+                    return String.Encoding(rawValue: se)
+                }
+            }
+            if #available(macOS 10.10, *) {
+                return data.stringEncoding ?? `default`
+            }
+            return `default`
+        }()
+
         self.init(data: data, encoding: encoding)
     }
 }

--- a/Sources/OpenGraph/OpenGraph.swift
+++ b/Sources/OpenGraph/OpenGraph.swift
@@ -67,7 +67,7 @@ public struct OpenGraph {
            !(200..<300).contains(response.statusCode) {
             throw OpenGraphResponseError.unexpectedStatusCode(response.statusCode)
         } else {
-            guard let htmlString = String(data: data, encoding: String.Encoding.utf8) else {
+            guard let htmlString = String(data: data, textEncodingName: response.textEncodingName) else {
                 throw OpenGraphParseError.encodingError
             }
             return OpenGraph(htmlString: htmlString)

--- a/Sources/OpenGraph/OpenGraph.swift
+++ b/Sources/OpenGraph/OpenGraph.swift
@@ -53,7 +53,7 @@ public struct OpenGraph {
         if !(200..<300).contains(response.statusCode) {
             completion(.failure(OpenGraphResponseError.unexpectedStatusCode(response.statusCode)))
         } else {
-            guard let htmlString = String(data: data) else {
+            guard let htmlString = String(data: data, textEncodingName: response.textEncodingName) else {
                 completion(.failure(OpenGraphParseError.encodingError))
                 return
             }


### PR DESCRIPTION
Thank you for providing a great library!

I used this library to Shift-JIS encoded website and got encodingError in a iOS app.
This library now supports multiple encoding only on macOS by #52.

So I changed code to support multiple encoding regardless of platforms.