### PR TITLE
Allow parsing `<meta name="og:..."`

### DIFF
--- a/Sources/OpenGraph/OpenGraphParser.swift
+++ b/Sources/OpenGraph/OpenGraphParser.swift
@@ -20,7 +20,7 @@ extension OpenGraphParser {
 
         // prepare regular expressions to extract og property and content.
         let propertyRegexp = try! NSRegularExpression(
-            pattern: "\\sproperty=(?:\"|\')*og:([a-zA_Z:]+)(?:\"|\')*",
+            pattern: "\\s(?:property|name)=(?:\"|\')*og:([a-zA_Z:]+)(?:\"|\')*",
             options: []
         )
         let contentRegexp = try! NSRegularExpression(

--- a/Tests/OpenGraphTests.swift
+++ b/Tests/OpenGraphTests.swift
@@ -171,6 +171,8 @@ class OpenGraphTests: XCTestCase {
         XCTAssert(OpenGraph(htmlString: html)[.description] == "It's a description")
         html = "<meta property=\"og:title\" content=\"It's a title contains single quote\"/>"
         XCTAssert(OpenGraph(htmlString: html)[.title] == "It's a title contains single quote")
+        html = "<meta name=\"og:title\" content=\"It's a title contains single quote\"/>"
+        XCTAssert(OpenGraph(htmlString: html)[.title] == "It's a title contains single quote")
 
         html = "<meta content='It&#39;s a description' property='og:description' />"
         XCTAssert(OpenGraph(htmlString: html)[.description] == "It&#39;s a description")


### PR DESCRIPTION
Even though the standard OG wraps tags in meta `property` fields, some web pages are using this syntax to hold OG metadata:
```
<meta name="og:title" content="Sharing Debugger - Meta for Developers" />
```

See [this example](https://developers.facebook.com/tools/debug/) from Meta who proposed Open Graph protocol ;).

This PR adds such support to make this library more flexible.