### PR TITLE
fix package in Xcode 16.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "OpenGraph",
     platforms: [
-            .macOS(.v10_15), .iOS(.v10), .tvOS(.v9), .watchOS(.v2)
+            .macOS(.v10_15), .iOS(.v13), .tvOS(.v9), .watchOS(.v2)
     ],
     products: [
         .library(name: "OpenGraph", targets: ["OpenGraph"]),


### PR DESCRIPTION
'stringEncoding' is only available in iOS 13 or newer